### PR TITLE
Pynics would not install successfully on Python 3.9

### DIFF
--- a/pynics/__main__.py
+++ b/pynics/__main__.py
@@ -12,7 +12,7 @@ from ase import io
 from pynics.nics import NicsCompute
 from pynics.freeform import nicsfile
 from pynics.binparse import CurrentFile
-from soprano.properties.nmr.utils import _haeb_sort, _anisotropy, _asymmetry
+from soprano.nmr.utils import _haeb_sort, _anisotropy, _asymmetry
 
 
 def nics_buildup(args=None):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ setup(name='pynics',
       packages=find_packages(),
       install_requires=[
           'numpy',
-          'ase'
+          'ase',
+          'soprano>=0.8.10'
       ],      
       entry_points={
           'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(name='pynics',
       version='0.1.0',
-      packages=['pynics'],
+      packages=find_packages(),
       install_requires=[
           'numpy',
           'ase'
@@ -12,4 +12,5 @@ setup(name='pynics',
               'lorentz_buildup_nics = pynics.__main__:nics_buildup'
           ]
       },
-      )
+      include_package_data=True,
+)


### PR DESCRIPTION
Pynics would not install on Python 3.9 on Fedora 34, as the soprano pip file had a different submodule layout and the setup.py did not install the submodules freeform and binparse. This pull request changes the soprano import to match the layout in pip, and makes it install the freeform and binparse submodules.