### PR TITLE
Add -csv option to change output file

### DIFF
--- a/pynics/__main__.py
+++ b/pynics/__main__.py
@@ -31,7 +31,7 @@ def nics_buildup(args=None):
                         help=("Prefix for output file names "
                               "(default is the seedname)"))
     parser.add_argument('-csv', action='store_true', default=False,
-                        help="Output NICS tensors in CSV format instead of table format")
+                        help="Output NICS tensors in CSV format")
     args = parser.parse_args()
 
     cfile = CurrentFile(args.cfile)

--- a/pynics/__main__.py
+++ b/pynics/__main__.py
@@ -29,8 +29,7 @@ def nics_buildup(args=None):
     parser.add_argument('-out', type=str, default=None,
                         help=("Prefix for output file names "
                               "(default is the seedname)"))
-    parser.add_argument('-csv', action='store_true', default=False,
-                        help="output NICS tensors in CSV format instead of table format")
+
     args = parser.parse_args()
 
     cfile = CurrentFile(args.cfile)
@@ -53,7 +52,8 @@ def nics_buildup(args=None):
     outname = args.seedname if args.out is None else args.out
 
     outnics = open(outname + '_nics.txt', 'w')
-
+    outcsv = open(outname + '_nics.csv', 'w')
+    
     for ptype, plist in allpoints.items():
         if plist is None:
             continue
@@ -65,19 +65,18 @@ def nics_buildup(args=None):
                                                     is_log=args.log)
 
             # Print output
-            if (args.csv):
-                outnics.write('%d, %f, %f\n' % (i+1, np.trace(nics.nics)/3.0, np.trace(nics.nics_plus_chi)/3.0))
-            else:
-                outnics.write('Point {0}_{1}:\n'.format(ptype, i+1))
-                outnics.write('Coordinates: {0} {1} {2}\n'.format(*p))
-                outnics.write('NICS isotropy: {0} ppm\n'.format(
-                    np.trace(nics.nics)/3.0))
-                outnics.write(
-                    'NICS+chi isotropy: {0} ppm\n'.format(
-                        np.trace(nics.nics_plus_chi)/3.0))
-                outnics.write('NICS tensor:\n{0}\n'.format(nics.nics))
-                outnics.write('NICS+chi tensor:\n{0}\n'.format(nics.nics_plus_chi))
-                outnics.write('\n------\n')
+            outcsv.write('%d, %f, %f\n' % (i+1, np.trace(nics.nics)/3.0, np.trace(nics.nics_plus_chi)/3.0))
+
+            outnics.write('Point {0}_{1}:\n'.format(ptype, i+1))
+            outnics.write('Coordinates: {0} {1} {2}\n'.format(*p))
+            outnics.write('NICS isotropy: {0} ppm\n'.format(
+                np.trace(nics.nics)/3.0))
+            outnics.write(
+                'NICS+chi isotropy: {0} ppm\n'.format(
+                    np.trace(nics.nics_plus_chi)/3.0))
+            outnics.write('NICS tensor:\n{0}\n'.format(nics.nics))
+            outnics.write('NICS+chi tensor:\n{0}\n'.format(nics.nics_plus_chi))
+            outnics.write('\n------\n')
 
             # For buildup, let's diagonalize them
             all_evals = np.array([np.linalg.eigh((nb+nb.T)/2.0)[0]

--- a/pynics/__main__.py
+++ b/pynics/__main__.py
@@ -29,6 +29,8 @@ def nics_buildup(args=None):
     parser.add_argument('-out', type=str, default=None,
                         help=("Prefix for output file names "
                               "(default is the seedname)"))
+    parser.add_argument('-csv', action='store_true', default=False,
+                        help="output NICS tensors in CSV format instead of table format")
     args = parser.parse_args()
 
     cfile = CurrentFile(args.cfile)
@@ -55,6 +57,10 @@ def nics_buildup(args=None):
     for ptype, plist in allpoints.items():
         if plist is None:
             continue
+        
+        if (args.csv):
+            outnics.write("# point, NICS isotropy, NICS+chi isotropy\n")
+            
         for i, p in enumerate(plist):
             nics = ncomp.get_nics(p)
             rrange, nbuild = ncomp.get_nics_buildup(p, Rmax=args.R, n=args.n,
@@ -62,16 +68,19 @@ def nics_buildup(args=None):
                                                     is_log=args.log)
 
             # Print output
-            outnics.write('Point {0}_{1}:\n'.format(ptype, i+1))
-            outnics.write('Coordinates: {0} {1} {2}\n'.format(*p))
-            outnics.write('NICS isotropy: {0} ppm\n'.format(
-                np.trace(nics.nics)/3.0))
-            outnics.write(
-                'NICS+chi isotropy: {0} ppm\n'.format(
-                    np.trace(nics.nics_plus_chi)/3.0))
-            outnics.write('NICS tensor:\n{0}\n'.format(nics.nics))
-            outnics.write('NICS+chi tensor:\n{0}\n'.format(nics.nics_plus_chi))
-            outnics.write('\n------\n')
+            if (args.csv):
+                outnics.write('%d, %f, %f\n' % (i+1, np.trace(nics.nics)/3.0, np.trace(nics.nics_plus_chi)/3.0))
+            else:
+                outnics.write('Point {0}_{1}:\n'.format(ptype, i+1))
+                outnics.write('Coordinates: {0} {1} {2}\n'.format(*p))
+                outnics.write('NICS isotropy: {0} ppm\n'.format(
+                    np.trace(nics.nics)/3.0))
+                outnics.write(
+                    'NICS+chi isotropy: {0} ppm\n'.format(
+                        np.trace(nics.nics_plus_chi)/3.0))
+                outnics.write('NICS tensor:\n{0}\n'.format(nics.nics))
+                outnics.write('NICS+chi tensor:\n{0}\n'.format(nics.nics_plus_chi))
+                outnics.write('\n------\n')
 
             # For buildup, let's diagonalize them
             all_evals = np.array([np.linalg.eigh((nb+nb.T)/2.0)[0]

--- a/pynics/__main__.py
+++ b/pynics/__main__.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 import sys
 import numpy as np
 import argparse as ap
+import csv
 
 from ase import io
 from pynics.nics import NicsCompute
@@ -29,7 +30,8 @@ def nics_buildup(args=None):
     parser.add_argument('-out', type=str, default=None,
                         help=("Prefix for output file names "
                               "(default is the seedname)"))
-
+    parser.add_argument('-csv', action='store_true', default=False,
+                        help="Output NICS tensors in CSV format instead of table format")
     args = parser.parse_args()
 
     cfile = CurrentFile(args.cfile)
@@ -53,6 +55,7 @@ def nics_buildup(args=None):
 
     outnics = open(outname + '_nics.txt', 'w')
     outcsv = open(outname + '_nics.csv', 'w')
+    csvwriter = csv.writer(outcsv)
     
     for ptype, plist in allpoints.items():
         if plist is None:
@@ -65,7 +68,9 @@ def nics_buildup(args=None):
                                                     is_log=args.log)
 
             # Print output
-            outcsv.write('%d, %f, %f\n' % (i+1, np.trace(nics.nics)/3.0, np.trace(nics.nics_plus_chi)/3.0))
+            if (args.csv):
+                csvwriter.writerow([i+1, np.trace(nics.nics)/3.0, np.trace(nics.nics_plus_chi)/3.0])
+               
 
             outnics.write('Point {0}_{1}:\n'.format(ptype, i+1))
             outnics.write('Coordinates: {0} {1} {2}\n'.format(*p))
@@ -90,3 +95,4 @@ def nics_buildup(args=None):
                        np.array([rrange, iso, aniso, asymm]).T)
 
     outnics.close()
+    outcsv.close()

--- a/pynics/__main__.py
+++ b/pynics/__main__.py
@@ -57,10 +57,7 @@ def nics_buildup(args=None):
     for ptype, plist in allpoints.items():
         if plist is None:
             continue
-        
-        if (args.csv):
-            outnics.write("# point, NICS isotropy, NICS+chi isotropy\n")
-            
+
         for i, p in enumerate(plist):
             nics = ncomp.get_nics(p)
             rrange, nbuild = ncomp.get_nics_buildup(p, Rmax=args.R, n=args.n,

--- a/pynics/__main__.py
+++ b/pynics/__main__.py
@@ -54,8 +54,9 @@ def nics_buildup(args=None):
     outname = args.seedname if args.out is None else args.out
 
     outnics = open(outname + '_nics.txt', 'w')
-    outcsv = open(outname + '_nics.csv', 'w')
-    csvwriter = csv.writer(outcsv)
+    if (args.csv):
+        outcsv = open(outname + '_nics.csv', 'w')
+        csvwriter = csv.writer(outcsv)
     
     for ptype, plist in allpoints.items():
         if plist is None:
@@ -95,4 +96,4 @@ def nics_buildup(args=None):
                        np.array([rrange, iso, aniso, asymm]).T)
 
     outnics.close()
-    outcsv.close()
+    if (args.csv): outcsv.close()


### PR DESCRIPTION
Adds a new -csv option to lorentz_buildup_nics which outputs the NICS and NICS+chi isotropy into a CSV file instead of a table format.